### PR TITLE
Make secondary button's height the same as the primary

### DIFF
--- a/app/common/StyledButton.js
+++ b/app/common/StyledButton.js
@@ -28,7 +28,7 @@ const styles = (theme) => ({
 	flatSecondary: {
 		color: theme.palette.primary.main,
 		backgroundColor: theme.palette.primary.contrastText,
-		border: `1px solid ${theme.palette.primary.main}`,
+		boxShadow: `0 0 0 1px ${theme.palette.primary.main} inset`,
 
 		'&:hover': {
 			opacity: 0.6,


### PR DESCRIPTION
Currently, if you look at the log in button and the be a speaker buttons, you can see they don't have the same height.  This PR fixes that.